### PR TITLE
DO NOT MERGE: add provider by $MASTER env var

### DIFF
--- a/MASTER_provider.yml
+++ b/MASTER_provider.yml
@@ -1,0 +1,33 @@
+---
+- hosts: localhost
+  gather_facts: no  # setup is slow for me for some reason, don't need it
+
+  tasks:
+  - set_fact:
+      MASTER: '{{ lookup("env", "MASTER") }}'
+      SSL: '{{ ssl | default(True) | bool }}'
+      CA_PATH: '{{ ssl | default(True) | bool | ternary(lookup("env", "HOME") + "/" + lookup("env", "MASTER") + ".ca.crt", "") }}'
+      TOKEN_PATH: '{{ lookup("env", "HOME") + "/" + lookup("env", "MASTER") + ".token" }}'
+  - debug: var=CA_PATH
+  - debug: var=TOKEN_PATH
+  - name: Add Openshift Containers Provider to ManageIQ
+    manageiq_provider:
+      state: '{{ state | default("present") }}'
+      name: '{{ MASTER }}'
+      provider_type: 'openshift-origin'
+      state: 'present'
+      provider_api_hostname: '{{ MASTER }}'
+      provider_api_port: '8443'
+      provider_api_auth_token: '{{ lookup("file", TOKEN_PATH) }}'
+      provider_verify_ssl: '{{ SSL }}'
+      provider_ca_path: '{{ SSL | ternary(CA_PATH, omit) }}'
+      monitoring: 'hawkular'
+      monitoring_hostname: '{{ MASTER }}'  # TODO check route?
+      monitoring_port: '443'
+      miq_url: 'http://localhost:3000'
+      miq_username: 'admin'
+      miq_password: 'smartvm'
+      #miq_verify_ssl: false
+    register: result
+
+  - debug: var=result


### PR DESCRIPTION
I have a scheme I'm really happy with,
where I set `$MASTER` env var to openshift hostname,
create a `~/$MASTER.ca.crt` and `~/$MASTER.token`,
and can reuse commands in my history.

I use this playbook to add $MASTER provider to MIQ.

ca.crt can normally be got by `scp root@$MASTER:/etc/origin/master/ca.crt ~/$MASTER.ca.crt`

Running this playbook:
```
ansible-playbook ~/manageiq-ansible-module/MASTER_provider.yml
# if you didn't bother to obtain .ca.crt
ansible-playbook ~/manageiq-ansible-module/MASTER_provider.yml -e ssl=false  
# to delete
ansible-playbook ~/manageiq-ansible-module/MASTER_provider.yml -e state=absent
```
(a playbook at root of manageiq-ansible-module/ checkout finds the manageiq_* modules automagically)

----

Useful generic commands:
```
oc login --certificate-authority=$HOME/$MASTER.ca.crt --token="$(cat $HOME/$MASTER.token)" https://$MASTER:8443
# and now any `oc` commands talk to it...
```

Directly probe openshift API:
```
curl --cacert ~/$MASTER.ca.crt -H "Authorization: Bearer $(cat ~/$MASTER.token)" "https://$MASTER:8443/api/v1/pods"
```

Instantiate kubeclient in pry / rails console (one line for Ctrl+R history):
```
require 'kubeclient'; kclient, oclient = ['api', 'oapi'].map { |api| Kubeclient::Client.new("https://#{ENV['MASTER']}:8443/#{api}", auth_options: {bearer_token: File.read("#{ENV['HOME']}/#{ENV['MASTER']}.token")}, ssl_options: {ca_file: "#{ENV['HOME']}/#{ENV['MASTER']}.ca.crt"}) }
```
(in rails console, given a containers EMS, `ems.connect(path: '/api')` or `ems.connect(path: '/oapi')` works.  Default path depends on Kubernetes:: vs OpenShift::ContainerManager.)

Debugging openshift certs:
```
openssl s_client -showcerts -servername $MASTER -connect $MASTER:443 < /dev/null
openssl s_client -showcerts -servername $MASTER -connect $MASTER:443 < /dev/null | openssl x509 -text  # dumps only first cert
```